### PR TITLE
引数の型を修正

### DIFF
--- a/app/controllers/premium/messages_controller.rb
+++ b/app/controllers/premium/messages_controller.rb
@@ -1,6 +1,6 @@
 class Premium::MessagesController < Premium
     before_action :set_user, only: [:profile]
-    
+
   def index
     @pre_id = params[:user_id]
     @partnerships = Partnership.where("user_id = ? or target_id = ?", @pre_id, @pre_id)
@@ -9,7 +9,7 @@ class Premium::MessagesController < Premium
   end
 
   def show
-    @pre_id = params[:sender_id]
+    @pre_id = params[:sender_id].to_i
     @partnership = Partnership.find(params[:id])
     @partner = @partnership.user == current_user ? @partnership.target : @partnership.user
     @messages = Message.where(partnership_id: params[:id]).order("id").reverse_order.page(params[:page]).per(20)
@@ -20,7 +20,7 @@ class Premium::MessagesController < Premium
     @pre_id = params[:user_id]
     @message = Message.new(message_params)
     if @message.save
-      redirect_to premium_message_path(@message.partnership_id) 
+      redirect_to premium_message_path(@message.partnership_id)
     end
   end
 


### PR DESCRIPTION
メッセージの右か左かの判定は、premium/messages/show.html.slimの26行目
「if m.sender_id == @pre_id」でしている。
修正前は、@pre_idの中身はstring型になっていた。
sender_idはint型のため等しくならなかった。

premium/messages_controller.rbの12行目の
@pre_id = params[:sender_id]にto_iをつけて
string型からint型に変更する。
