### PR TITLE
[add] signup後にメール認証送信（準備)

### DIFF
--- a/app/controllers/guest/pages_controller.rb
+++ b/app/controllers/guest/pages_controller.rb
@@ -1,7 +1,9 @@
 class Guest::PagesController < Guest
+  # before_action :authenticate_user!, only: [:show]
   layout 'application'
 
   def index
+    
   end
 
   def welcome

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -70,9 +70,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
 
-  def after_inactive_sign_up_path_for(resource)
-    admin_user_mail_sent_message_path
-  end
+  # def after_inactive_sign_up_path_for(resource)
+  #   admin_user_index_path
+  # end
 
   protected
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :omniauthable
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, :confirmable
+         
 
   has_one :user_profile,  class_name: 'UserProfile',  dependent: :destroy, inverse_of: :user
   has_one :status,  class_name: 'UserStatus',  dependent: :destroy, inverse_of: :user, :foreign_key => 'user_id'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,5 +44,18 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # device
+  # send email-auth after signup 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # mail setting
+  # oDo: お名前.comでSMTPサーバの用意ができたら書く！
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => "smtpサーバー名",
+    :port => '587',
+    :user_name => "アカウント名",
+    :password => "パスワード",
+    :authentication => :login,
+    :enable_starttls_auto => true
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,9 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # ToDo: お名前.comでSMTPサーバの用意ができたら書く！
+  config.mailer_sender = '使用するメールアドレス'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/migrate/20181031125145_add_confirmable_to_devise.rb
+++ b/db/migrate/20181031125145_add_confirmable_to_devise.rb
@@ -1,0 +1,16 @@
+class AddConfirmableToDevise < ActiveRecord::Migration
+  # Note: You can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    User.all.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170927120825) do
+ActiveRecord::Schema.define(version: 20181031125145) do
 
   create_table "announcements", force: :cascade do |t|
     t.integer  "user_id",         limit: 4
@@ -255,8 +255,13 @@ ActiveRecord::Schema.define(version: 20170927120825) do
     t.string   "image",                  limit: 255
     t.string   "name",                   limit: 255
     t.datetime "deleted_at"
+    t.string   "confirmation_token",     limit: 255
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email",      limit: 255
   end
 
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["deleted_at"], name: "index_users_on_deleted_at", using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree


### PR DESCRIPTION
devise

signup 後にメール認証させる仕様。

※お名前.comでメールドメイン作成しSMTPサーバ情報が付与されてからじゃないと続きが書けない。
